### PR TITLE
create get_data.R functions to load MovieLens data sets

### DIFF
--- a/source_code/R/get_data.R
+++ b/source_code/R/get_data.R
@@ -1,0 +1,76 @@
+library(readr)
+library(dtplyr) 
+library(dplyr)
+
+ROOT <- rprojroot::find_rstudio_root_file()
+DATA_PATH <- paste0(ROOT, "/data/")
+
+get_movielens_small_ratings <- function(){
+  read_csv(paste0(DATA_PATH, "movielens/small/ratings.csv"))
+}
+
+get_movielens_small_movies <- function(){
+  read_csv(paste0(DATA_PATH, "movielens/small/movies.csv"))
+}
+
+get_movielens_small_tags <- function(){
+  read_csv(paste0(DATA_PATH, "movielens/small/tags.csv"))
+}
+
+get_movielens_small <- function(){
+  df_ratings <- get_movielens_small_ratings() %>% 
+    lazy_dt()
+    select(userId, movieId, rating)
+  
+  df_movies <- get_movielens_small_movies()
+
+  df_ratings %>%
+    left_join(df_movies, by = "movieId") %>% 
+    select(userId, movieId, title, rating)
+}
+
+get_movielens_medium_ratings <- function(){
+  read_csv(paste0(DATA_PATH, "movielens/medium/ratings.csv"))
+}
+
+get_movielens_medium_movies <- function(){
+  read_csv(paste0(DATA_PATH, "movielens/medium/movies.csv"))
+}
+
+get_movielens_medium_tags <- function(){
+  read_csv(paste0(DATA_PATH, "movielens/medium/tags.csv"))
+}
+
+get_movielens_medium <- function(){
+  df_ratings <- get_movielens_medium_ratings() %>% 
+    select(userId, movieId, rating)
+  
+  df_movies <- get_movielens_medium_movies()
+  
+  df_ratings %>%
+    left_join(df_movies, by = "movieId") %>% 
+    select(userId, movieId, title, rating)
+}
+
+get_movielens_large_ratings <- function(){
+  read_csv(paste0(DATA_PATH, "movielens/large/ratings.csv"))
+}
+
+get_movielens_large_movies <- function(){
+  read_csv(paste0(DATA_PATH, "movielens/large/movies.csv"))
+}
+
+get_movielens_large_tags <- function(){
+  read_csv(paste0(DATA_PATH, "movielens/large/tags.csv"))
+}
+
+get_movielens_large <- function(){
+  df_ratings <- get_movielens_large_ratings() %>% 
+    select(userId, movieId, rating)
+  
+  df_movies <- get_movielens_large_movies()
+  
+  df_ratings %>%
+    left_join(df_movies, by = "movieId") %>% 
+    select(userId, movieId, title, rating)
+}


### PR DESCRIPTION
This pull request adds `get_movielens_*()` R functions where `*` can be `small`, `medium`, or `large`. The main loading functions are:

`get_movielens_small()` retrieves the MovieLens 100k ratings data set and returns it as an R tibble object.
`get_movielens_medium()` retrieves the MovieLens 10M ratings data set and returns it as an R tibble object.
`get_movielens_large()` retrives the MovieLens 25M ratings data set and returns it as an R tibble object.

Other auxillary loading functions are also added for modularity and support.